### PR TITLE
Refactor blueprint registration and app initialization

### DIFF
--- a/app/blueprints/__init__.py
+++ b/app/blueprints/__init__.py
@@ -1,0 +1,13 @@
+"""Collections of Flask blueprints grouped by domain."""
+
+from app.blueprints.admin import ADMIN_BLUEPRINTS
+from app.blueprints.annotations import ANNOTATION_BLUEPRINTS
+from app.blueprints.core import CORE_BLUEPRINTS
+from app.blueprints.scenarios import SCENARIO_BLUEPRINTS
+
+__all__ = [
+    "ADMIN_BLUEPRINTS",
+    "ANNOTATION_BLUEPRINTS",
+    "CORE_BLUEPRINTS",
+    "SCENARIO_BLUEPRINTS",
+]

--- a/app/blueprints/admin.py
+++ b/app/blueprints/admin.py
@@ -1,0 +1,16 @@
+"""Administrative blueprint registrations."""
+
+from typing import Dict, List, Tuple
+from flask import Blueprint
+
+from app.routes.admin import admin_bp
+from app.routes.admin_prompts import admin_prompts_bp
+from app.routes.prompt_builder import prompt_builder_bp
+
+BlueprintRegistration = Tuple[Blueprint, Dict]
+
+ADMIN_BLUEPRINTS: List[BlueprintRegistration] = [
+    (admin_bp, {}),
+    (admin_prompts_bp, {}),
+    (prompt_builder_bp, {}),
+]

--- a/app/blueprints/annotations.py
+++ b/app/blueprints/annotations.py
@@ -1,0 +1,24 @@
+"""Annotation-related blueprint registrations."""
+
+from typing import Dict, List, Tuple
+from flask import Blueprint
+
+from app.routes.annotations import annotations_bp
+from app.routes.api_document_annotations import bp as api_document_annotations_bp
+from app.routes.annotation_review import bp as annotation_review_bp
+from app.routes.annotation_versions import annotation_versions_bp
+from app.routes.enhanced_annotations import bp as enhanced_annotations_bp
+from app.routes.intelligent_annotations import intelligent_annotations_bp
+from app.routes.llm_annotations import bp as llm_annotations_bp
+
+BlueprintRegistration = Tuple[Blueprint, Dict]
+
+ANNOTATION_BLUEPRINTS: List[BlueprintRegistration] = [
+    (annotations_bp, {}),
+    (intelligent_annotations_bp, {}),
+    (enhanced_annotations_bp, {}),
+    (llm_annotations_bp, {}),
+    (annotation_review_bp, {}),
+    (annotation_versions_bp, {}),
+    (api_document_annotations_bp, {}),
+]

--- a/app/blueprints/core.py
+++ b/app/blueprints/core.py
@@ -1,0 +1,62 @@
+"""Core blueprint registrations for the ProEthica application."""
+
+from typing import Dict, List, Tuple
+from flask import Blueprint
+
+from app.routes.agent import agent_bp
+from app.routes.cases import cases_bp
+from app.routes.characters import characters_bp
+from app.routes.conditions import conditions_bp
+from app.routes.dashboard import dashboard_bp
+from app.routes.debug import debug_bp
+from app.routes.debug_env import debug_env_bp
+from app.routes.documents import documents_bp
+from app.routes.domains import domains_bp
+from app.routes.events import events_bp
+from app.routes.experiment import experiment_bp
+from app.routes.guidelines import guidelines_bp
+from app.routes.index import index_bp
+from app.routes.ontology import ontology_bp
+from app.routes.provenance import provenance_bp
+from app.routes.reasoning import reasoning_bp
+from app.routes.resources import resources_bp
+from app.routes.roles import roles_bp
+from app.routes.simulation import simulation_bp
+from app.routes.test_routes import test_bp
+from app.routes.type_management import type_management_bp
+from app.routes.wizard import wizard_bp
+from app.routes.worlds import worlds_bp
+from app.routes.worlds_extract_only import worlds_extract_only_bp
+from app.routes.document_structure import doc_structure_bp
+from app.routes.auth import auth_bp
+
+BlueprintRegistration = Tuple[Blueprint, Dict]
+
+CORE_BLUEPRINTS: List[BlueprintRegistration] = [
+    (index_bp, {}),
+    (auth_bp, {}),
+    (dashboard_bp, {"url_prefix": "/dashboard"}),
+    (worlds_bp, {"url_prefix": "/worlds"}),
+    (domains_bp, {"url_prefix": "/domains"}),
+    (roles_bp, {"url_prefix": "/roles"}),
+    (resources_bp, {"url_prefix": "/resources"}),
+    (conditions_bp, {"url_prefix": "/conditions"}),
+    (characters_bp, {"url_prefix": "/characters"}),
+    (events_bp, {"url_prefix": "/events"}),
+    (simulation_bp, {"url_prefix": "/simulation"}),
+    (ontology_bp, {"url_prefix": "/ontology"}),
+    (debug_bp, {"url_prefix": "/debug"}),
+    (documents_bp, {"url_prefix": "/documents"}),
+    (cases_bp, {"url_prefix": "/cases"}),
+    (doc_structure_bp, {}),
+    (experiment_bp, {"url_prefix": "/experiment"}),
+    (type_management_bp, {}),
+    (debug_env_bp, {}),
+    (wizard_bp, {}),
+    (test_bp, {}),
+    (guidelines_bp, {}),
+    (worlds_extract_only_bp, {}),
+    (agent_bp, {}),
+    (reasoning_bp, {}),
+    (provenance_bp, {}),
+]

--- a/app/blueprints/scenarios.py
+++ b/app/blueprints/scenarios.py
@@ -1,0 +1,20 @@
+"""Scenario-related blueprint registrations."""
+
+from typing import Dict, List, Tuple
+from flask import Blueprint
+
+from app.routes.scenario_pipeline import interactive_scenario_bp
+from app.routes.scenario_pipeline.entity_review import bp as entity_review_bp
+from app.routes.scenario_pipeline.step4 import bp as step4_bp
+from app.routes.scenario_pipeline.step5 import bp as step5_bp
+from app.routes.scenarios import scenarios_bp
+
+BlueprintRegistration = Tuple[Blueprint, Dict]
+
+SCENARIO_BLUEPRINTS: List[BlueprintRegistration] = [
+    (scenarios_bp, {"url_prefix": "/scenarios"}),
+    (interactive_scenario_bp, {}),
+    (entity_review_bp, {"url_prefix": "/scenario_pipeline"}),
+    (step4_bp, {}),
+    (step5_bp, {}),
+]

--- a/app/utils/app_init.py
+++ b/app/utils/app_init.py
@@ -1,0 +1,40 @@
+"""Helpers for initializing the Flask application."""
+
+import os
+from sqlalchemy import create_engine
+
+
+def smoke_test_db_connection(app):
+    """Perform a lightweight database connection test."""
+    with app.app_context():
+        try:
+            engine = create_engine(app.config['SQLALCHEMY_DATABASE_URI'])
+            connection = engine.connect()
+            connection.close()
+
+            if os.environ.get('DEBUG', '').lower() == 'true':
+                print("Database connection successful.")
+        except Exception as e:
+            print(f"Warning: Database connection error: {str(e)}")
+            print("The application may not function correctly without database access.")
+
+
+def init_csrf_exemptions(app):
+    """Apply CSRF exemptions for routes that require it."""
+    from app.routes.api_document_annotations import init_csrf_exemption
+    from app.routes.cases import init_cases_csrf_exemption
+    from app.routes.scenario_pipeline.interactive_builder import init_csrf_exemption as init_scenario_csrf_exemption
+    from app.routes.scenario_pipeline.step1 import init_step1_csrf_exemption
+    from app.routes.scenario_pipeline.step2 import init_step2_csrf_exemption
+    from app.routes.scenario_pipeline.step3 import init_step3_csrf_exemption
+    from app.routes.scenario_pipeline.step4 import init_step4_csrf_exemption
+    from app.routes.scenario_pipeline.step5 import init_step5_csrf_exemption
+
+    init_csrf_exemption(app)
+    init_scenario_csrf_exemption(app)
+    init_cases_csrf_exemption(app)
+    init_step1_csrf_exemption(app)
+    init_step2_csrf_exemption(app)
+    init_step3_csrf_exemption(app)
+    init_step4_csrf_exemption(app)
+    init_step5_csrf_exemption(app)

--- a/tests/test_blueprint_registration.py
+++ b/tests/test_blueprint_registration.py
@@ -1,0 +1,30 @@
+"""Integration checks for blueprint registration."""
+
+from app import create_app
+from app.blueprints import (
+    ADMIN_BLUEPRINTS,
+    ANNOTATION_BLUEPRINTS,
+    CORE_BLUEPRINTS,
+    SCENARIO_BLUEPRINTS,
+)
+
+
+def _expected_blueprint_names():
+    expected = set()
+    for blueprint, _ in (
+        CORE_BLUEPRINTS
+        + SCENARIO_BLUEPRINTS
+        + ANNOTATION_BLUEPRINTS
+        + ADMIN_BLUEPRINTS
+    ):
+        expected.add(blueprint.name)
+    return expected
+
+
+def test_all_expected_blueprints_registered():
+    app = create_app('testing')
+    registered = set(app.blueprints.keys())
+
+    expected = _expected_blueprint_names()
+
+    assert expected.issubset(registered)


### PR DESCRIPTION
## Summary
- group blueprints into categorized modules and iterate registration within `create_app`
- extract database smoke test and CSRF exemption setup into reusable helpers
- add integration coverage to ensure all expected blueprints register with the app

## Testing
- PYTHONPATH=. pytest tests/test_blueprint_registration.py *(fails: ModuleNotFoundError: No module named 'flask')*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69211cf0095c832d8d94087525f7f45c)