### PR TITLE
Replace in-memory cosine index with pgvector query (canonicalization #2)

### DIFF
--- a/app/services/auto_commit_service.py
+++ b/app/services/auto_commit_service.py
@@ -10,7 +10,6 @@ Phase 3 of Entity-Ontology Linking implementation.
 
 import logging
 import json
-import numpy as np
 from datetime import datetime
 from typing import Dict, List, Any, Optional, Tuple
 from pathlib import Path
@@ -103,11 +102,10 @@ class AutoCommitService:
         self.ontologies_dir = self.ontserve_path / "ontologies"
         self.ontologies_dir.mkdir(parents=True, exist_ok=True)
 
-        # Cache for OntServe classes (loaded on demand)
+        # Cache for OntServe classes (loaded on demand) - used by exact-label
+        # and substring lexical matchers. Embedding lookups go directly to
+        # ontology_entities via pgvector and do not consult this cache.
         self._ontserve_classes_cache: Optional[Dict[str, Dict]] = None
-
-        # Embedding index built lazily from _ontserve_classes_cache
-        self._embedding_index: Optional[Dict] = None
 
         # Whether current commit uses versioned path (set by commit_case_entities)
         self._versioned_commit: bool = True
@@ -418,137 +416,76 @@ class AutoCommitService:
         # Embedding-based similarity fallback
         return self._check_embedding_duplicate(label, definition, entity_type)
 
-    def _build_embedding_index(self) -> None:
-        """Build in-memory cosine index over the loaded OntServe classes cache.
-
-        Called lazily before the first embedding lookup. Embeds 'label: definition'
-        for every proethica class using the same all-MiniLM-L6-v2 model (384-dim)
-        used for case-level embeddings. Stores an L2-normalised (N x 384) numpy
-        matrix so cosine similarity reduces to a single matrix-vector product.
-        """
-        if not self._ontserve_classes_cache:
-            self._embedding_index = {'matrix': None, 'uris': [], 'types': []}
-            return
-
-        try:
-            from app.services.embedding_service import EmbeddingService
-            embedding_service = EmbeddingService.get_instance()
-
-            uris: List[str] = []
-            types: List[str] = []
-            vectors: List[np.ndarray] = []
-
-            for uri, class_info in self._ontserve_classes_cache.items():
-                label = (class_info.get('label') or '').strip()
-                defn = (class_info.get('definition') or '').strip()
-                entity_type = (class_info.get('type') or '').lower()
-
-                index_text = f"{label}: {defn}" if defn else label
-                if not index_text:
-                    continue
-
-                raw = embedding_service._get_local_embedding(index_text)
-                vec = (
-                    np.array(raw, dtype=np.float32)
-                    if isinstance(raw, list)
-                    else raw.astype(np.float32)
-                )
-                norm = np.linalg.norm(vec)
-                if norm == 0:
-                    continue
-                vec = vec / norm
-
-                uris.append(uri)
-                types.append(entity_type)
-                vectors.append(vec)
-
-            if vectors:
-                self._embedding_index = {
-                    'matrix': np.stack(vectors, axis=0),
-                    'uris': uris,
-                    'types': types,
-                }
-            else:
-                self._embedding_index = {'matrix': None, 'uris': [], 'types': []}
-
-            logger.info("Built embedding index with %d proethica classes", len(uris))
-
-        except Exception as e:
-            logger.warning("Could not build embedding index: %s", e)
-            self._embedding_index = {'matrix': None, 'uris': [], 'types': []}
-
     def _check_embedding_duplicate(
         self, label: str, definition: str, entity_type: str
     ) -> Optional[Tuple[str, float]]:
-        """Query the embedding index for a cosine-similar class.
+        """Query OntServe via pgvector for the nearest cosine match.
 
-        Embeds 'label: definition' with all-MiniLM-L6-v2, applies entity-type
-        filter, and returns (uri, cosine_score) if the best match meets
-        EMBEDDING_MATCH_MIN.  Rubric bands (ICCBR paper Section 3.3):
+        Embeds 'label: definition' with all-MiniLM-L6-v2 and runs a single
+        cosine query against ``ontology_entities.embedding`` (vector(384)
+        with an IVFFlat cosine index already in place). The candidate's
+        semantic type narrows the search to URIs containing the matching
+        marker ('Obligation', 'Capability', etc.). Returns (uri, cosine)
+        when the top match meets EMBEDDING_MATCH_MIN; otherwise None.
 
-          HIGH   cosine >= 0.85  -> caller applies auto-link logic
-          MEDIUM 0.70 <= c < 0.85 -> caller applies review-flag logic
-          below 0.70              -> returns None (novel class)
+        Rubric bands (ICCBR paper Section 3.3):
+          HIGH   cosine >= 0.85       -> caller applies auto-link logic
+          MEDIUM 0.70 <= c < 0.85     -> caller applies review-flag logic
+          below  0.70                  -> None (novel class)
         """
-        if self._embedding_index is None:
-            self._build_embedding_index()
-
-        matrix = (self._embedding_index or {}).get('matrix')
-        if matrix is None:
-            return None
-
-        uris: List[str] = self._embedding_index['uris']
-        types: List[str] = self._embedding_index['types']
-        if not uris:
-            return None
-
         try:
             from app.services.embedding_service import EmbeddingService
             embedding_service = EmbeddingService.get_instance()
 
             candidate_text = f"{label}: {definition}" if definition else label
             raw = embedding_service._get_local_embedding(candidate_text)
-            vec = (
-                np.array(raw, dtype=np.float32)
-                if isinstance(raw, list)
-                else raw.astype(np.float32)
-            )
-            norm = np.linalg.norm(vec)
-            if norm == 0:
+            vec = list(raw) if not isinstance(raw, list) else raw
+
+            # Build optional URI substring filter for the semantic type.
+            markers = _semantic_type_markers(entity_type)
+            params: Dict[str, Any] = {"vec": vec}
+            if markers:
+                like_clauses = []
+                for i, marker in enumerate(markers):
+                    key = f"m{i}"
+                    like_clauses.append(f"uri LIKE :{key}")
+                    params[key] = f"%{marker}%"
+                marker_sql = "AND (" + " OR ".join(like_clauses) + ")"
+            else:
+                marker_sql = ""
+
+            sql = text(f"""
+                SELECT uri, label,
+                       1 - (embedding <=> CAST(:vec AS vector)) AS cosine
+                FROM ontology_entities
+                WHERE entity_type = 'class'
+                  AND uri LIKE 'http://proethica.org/ontology/%'
+                  AND uri NOT LIKE 'http://proethica.org/ontology/core#%'
+                  AND embedding IS NOT NULL
+                  {marker_sql}
+                ORDER BY embedding <=> CAST(:vec AS vector)
+                LIMIT 1
+            """)
+
+            engine = create_engine(get_ontserve_db_url())
+            with engine.connect() as conn:
+                # IVFFlat default probes=1 is approximate. Bump to 100
+                # (matches the index list count, effectively exact scan)
+                # so the matcher doesn't miss the true nearest neighbor.
+                conn.execute(text("SET LOCAL ivfflat.probes = 100"))
+                row = conn.execute(sql, params).fetchone()
+
+            if row is None:
                 return None
-            vec = vec / norm
-
-            # Cosine similarity = dot product of L2-normalised vectors, shape (N,)
-            similarities: np.ndarray = matrix @ vec
-
-            # Type filter: candidates pass if the class URI contains the
-            # title-cased semantic type (e.g., 'Obligation' in URI for an
-            # 'obligation' candidate). The cache only holds class entities
-            # (entity_type='class' filter at SQL load), so the structural
-            # type is uninformative; the D-tuple component lives in the
-            # local-name suffix of the class URI by convention. A simple
-            # singularization keeps plural inputs ('obligations',
-            # 'capabilities') aligned with singular URI conventions.
-            type_markers = _semantic_type_markers(entity_type)
-            best_score = -1.0
-            best_uri: Optional[str] = None
-
-            for uri, _cls_type, sim in zip(uris, types, similarities):
-                sim_val = float(sim)
-                if type_markers and not any(m in uri for m in type_markers):
-                    continue
-                if sim_val > best_score:
-                    best_score = sim_val
-                    best_uri = uri
-
-            if best_uri is None or best_score < EMBEDDING_MATCH_MIN:
+            cosine = float(row.cosine)
+            if cosine < EMBEDDING_MATCH_MIN:
                 return None
 
             logger.info(
                 "Embedding match: '%s' (%s) -> %s (cosine=%.3f)",
-                label, entity_type, best_uri, best_score,
+                label, entity_type, row.uri, cosine,
             )
-            return best_uri, best_score
+            return row.uri, cosine
 
         except Exception as e:
             logger.warning("Embedding duplicate check failed: %s", e)
@@ -573,7 +510,6 @@ class AutoCommitService:
             """)
 
             # Use a separate connection to ontserve database
-            from sqlalchemy import create_engine
             ontserve_engine = create_engine(get_ontserve_db_url())
 
             with ontserve_engine.connect() as conn:

--- a/app/services/auto_commit_service.py
+++ b/app/services/auto_commit_service.py
@@ -370,21 +370,13 @@ class AutoCommitService:
     def _check_duplicate(
         self, label: str, entity_type: str, definition: str = ""
     ) -> Optional[Tuple[str, float]]:
-        """
-        Check if a semantically equivalent class already exists in OntServe.
+        """Find an existing OntServe class equivalent to the candidate.
 
-        First tries lexical matching (exact, then substring with type filter),
-        then falls back to embedding-based cosine similarity against all
-        proethica classes loaded from ontology_entities.
-
-        Args:
-            label: The entity label
-            entity_type: The type of entity (role, state, etc.)
-            definition: Optional entity definition for richer embedding text
-
-        Returns:
-            (uri, confidence) if a match is found, None otherwise.
-            Confidence: 1.0 for exact label, 0.87 for substring, cosine for embedding.
+        Tries exact label match, then substring match with a URI-marker
+        type filter, then falls back to pgvector cosine similarity.
+        Returns ``(uri, confidence)`` or ``None``. Confidence is 1.0 for
+        exact label, 0.87 for substring, and the cosine score for the
+        embedding path.
         """
         # Load OntServe classes if not cached
         if self._ontserve_classes_cache is None:
@@ -469,9 +461,7 @@ class AutoCommitService:
 
             engine = create_engine(get_ontserve_db_url())
             with engine.connect() as conn:
-                # IVFFlat default probes=1 is approximate. Bump to 100
-                # (matches the index list count, effectively exact scan)
-                # so the matcher doesn't miss the true nearest neighbor.
+                # Probe every list so the IVFFlat lookup is exact, not approximate.
                 conn.execute(text("SET LOCAL ivfflat.probes = 100"))
                 row = conn.execute(sql, params).fetchone()
 

--- a/tests/test_embedding_matcher.py
+++ b/tests/test_embedding_matcher.py
@@ -1,27 +1,9 @@
-"""
-Unit tests for embedding-based duplicate detection in AutoCommitService._check_duplicate.
+"""Unit tests for embedding-based duplicate detection.
 
-The matcher embeds 'label: definition' via all-MiniLM-L6-v2 and runs a single
-pgvector cosine query against ontology_entities. These tests mock both
-EmbeddingService (to control the candidate vector) and create_engine (to
-control the row returned by the SQL query). No real model, no real DB,
-no Flask app context.
-
-Coverage:
-  - High cosine (>= 0.85) -> (uri, score) auto-link band
-  - Medium cosine (0.70-0.85) -> (uri, score) review-flag band
-  - Low cosine (< 0.70) -> None (novel class)
-  - SQL returns no row -> None
-  - EmbeddingService raises -> None (and caller swallows)
-  - Type filter: marker LIKE clauses included in params for known type
-  - Plural/singular type variants both produce a usable marker
-  - Unknown semantic type falls back to title-cased form
-  - Empty entity_type omits LIKE filter entirely
-  - _check_duplicate: exact label -> (uri, 1.0)
-  - _check_duplicate: substring + type-marker match -> (uri, 0.87)
-  - _check_duplicate: substring with wrong type -> falls through
-  - _check_duplicate: empty cache + no SQL row -> None
-  - _check_duplicate: definition forwarded into embedding text
+The matcher embeds ``label: definition`` via all-MiniLM-L6-v2 and runs a
+single pgvector cosine query against ``ontology_entities``. These tests
+mock both ``EmbeddingService`` (candidate vector) and ``create_engine``
+(SQL row), so they run with no model, no DB, and no Flask app context.
 """
 
 from typing import Any, Dict, List, Optional
@@ -104,17 +86,17 @@ def _patch_pgvector(query_vec: List[float], sql_row, captured: Dict[str, Any]):
     return stack, mock_es_instance
 
 
-def _run_embedding(label, entity_type, definition, sql_row,
-                   query_vec=None, cache_entries=None):
-    """Drive _check_embedding_duplicate end to end with mocked deps.
+def _run_embedding(label, entity_type, definition, sql_row, query_vec=None):
+    """Drive ``_check_embedding_duplicate`` end-to-end with mocked deps.
 
-    Returns (result, captured) where result is the function's return and
-    captured has 'params' and 'sql' from the simulated SQL call.
+    Returns ``(result, captured)``. ``captured`` carries ``params`` and
+    ``sql`` from the simulated SQL call so callers can assert on the
+    bind values.
     """
     if query_vec is None:
-        query_vec = [0.1] * 384  # arbitrary; matcher does not see the vector
+        query_vec = [0.1] * 384
     captured: Dict[str, Any] = {}
-    service = _make_service(cache_entries)
+    service = _make_service()
     with _patch_pgvector(query_vec, sql_row, captured)[0]:
         result = service._check_embedding_duplicate(label, definition, entity_type)
     return result, captured

--- a/tests/test_embedding_matcher.py
+++ b/tests/test_embedding_matcher.py
@@ -1,88 +1,123 @@
 """
 Unit tests for embedding-based duplicate detection in AutoCommitService._check_duplicate.
 
-Fully mocked: no SentenceTransformer model, no Flask app context, no database.
-The embedding index is built directly on the service instance; only the
-query-time embedding call is patched.
+The matcher embeds 'label: definition' via all-MiniLM-L6-v2 and runs a single
+pgvector cosine query against ontology_entities. These tests mock both
+EmbeddingService (to control the candidate vector) and create_engine (to
+control the row returned by the SQL query). No real model, no real DB,
+no Flask app context.
 
 Coverage:
-  - High cosine (>= 0.85) -> auto-link band
-  - Medium cosine (0.70-0.85) -> review-flag band
-  - Low cosine (< 0.70) -> novel class (None)
-  - Type filter prevents cross-type matching
-  - Plural/singular type variants pass filter
-  - Best-match selection among multiple same-type classes
-  - Empty index returns None without error
+  - High cosine (>= 0.85) -> (uri, score) auto-link band
+  - Medium cosine (0.70-0.85) -> (uri, score) review-flag band
+  - Low cosine (< 0.70) -> None (novel class)
+  - SQL returns no row -> None
+  - EmbeddingService raises -> None (and caller swallows)
+  - Type filter: marker LIKE clauses included in params for known type
+  - Plural/singular type variants both produce a usable marker
+  - Unknown semantic type falls back to title-cased form
+  - Empty entity_type omits LIKE filter entirely
   - _check_duplicate: exact label -> (uri, 1.0)
-  - _check_duplicate: substring + type match -> (uri, 0.87)
-  - _check_duplicate: wrong type substring -> falls through to embedding
-  - _check_duplicate: unknown label falls through to embedding
-  - _check_duplicate: empty cache -> None
+  - _check_duplicate: substring + type-marker match -> (uri, 0.87)
+  - _check_duplicate: substring with wrong type -> falls through
+  - _check_duplicate: empty cache + no SQL row -> None
+  - _check_duplicate: definition forwarded into embedding text
 """
 
-import numpy as np
-import pytest
+from typing import Any, Dict, List, Optional
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _make_unit_vec(seed: int, dim: int = 384) -> np.ndarray:
-    """Deterministic unit vector."""
-    rng = np.random.RandomState(seed)
-    v = rng.randn(dim).astype(np.float32)
-    return v / np.linalg.norm(v)
+def _make_service(cache_entries: Optional[Dict[str, Dict]] = None):
+    """Create a bare AutoCommitService bypassing __init__.
 
-
-def _vec_with_cosine(target: np.ndarray, cosine: float) -> np.ndarray:
-    """Unit vector with specified cosine similarity to *target*.
-
-    Decomposition: result = cosine*target + sin*perp, where perp is orthogonal.
-    """
-    target = target.astype(np.float32)
-    # Build a vector orthogonal to target
-    perp = np.zeros_like(target)
-    perp[0] = -target[1]
-    perp[1] = target[0]
-    if np.linalg.norm(perp) < 1e-6:
-        perp = np.zeros_like(target)
-        perp[1] = 1.0
-    perp = perp - np.dot(perp, target) * target
-    norm_p = np.linalg.norm(perp)
-    if norm_p < 1e-6:
-        return target.copy()
-    perp = perp / norm_p
-    sin_val = float(np.sqrt(max(0.0, 1.0 - cosine ** 2)))
-    result = cosine * target + sin_val * perp
-    return result / np.linalg.norm(result)
-
-
-def _make_service(index_uris, index_types, index_vectors, cache_entries=None):
-    """Create a bare AutoCommitService with a pre-built embedding index.
-
-    Bypasses __init__ entirely to avoid Flask/DB dependencies.
+    Skips Flask app and DB setup so the tests run in plain pytest.
     """
     from app.services.auto_commit_service import AutoCommitService
-
     service = object.__new__(AutoCommitService)
     service._versioned_commit = True
-
-    if index_vectors:
-        matrix = np.stack(
-            [v / np.linalg.norm(v) for v in index_vectors], axis=0
-        ).astype(np.float32)
-    else:
-        matrix = None
-
-    service._embedding_index = {
-        'matrix': matrix,
-        'uris': list(index_uris),
-        'types': list(index_types),
-    }
-    service._ontserve_classes_cache = cache_entries if cache_entries is not None else {}
+    service._ontserve_classes_cache = (
+        cache_entries if cache_entries is not None else {}
+    )
     return service
+
+
+def _make_row(uri: str, label: str, cosine: float):
+    """Mimic a SQLAlchemy Row that supports attribute access."""
+    row = MagicMock()
+    row.uri = uri
+    row.label = label
+    row.cosine = cosine
+    return row
+
+
+def _patch_pgvector(query_vec: List[float], sql_row, captured: Dict[str, Any]):
+    """Context-manager helper: patches EmbeddingService and create_engine.
+
+    sql_row may be a row mock, None (no match), or an Exception (raised by
+    fetchone). captured["params"] is filled with the SQL bind params after
+    execute() runs so tests can assert on the LIKE filters.
+    """
+    from contextlib import ExitStack
+
+    stack = ExitStack()
+    es_patch = stack.enter_context(
+        patch("app.services.embedding_service.EmbeddingService")
+    )
+    engine_patch = stack.enter_context(
+        patch("app.services.auto_commit_service.create_engine")
+    )
+
+    # candidate-side embedding
+    mock_es_instance = MagicMock()
+    mock_es_instance._get_local_embedding.return_value = query_vec
+    es_patch.get_instance.return_value = mock_es_instance
+
+    # SQL query result
+    mock_conn = MagicMock()
+
+    def _execute(sql, params=None):
+        sql_str = str(sql)
+        # SET LOCAL ivfflat.probes runs before the SELECT and has no params;
+        # only capture the SELECT call so tests can inspect bind values.
+        if "SELECT" in sql_str.upper() and params is not None:
+            captured["params"] = dict(params)
+            captured["sql"] = sql_str
+        result = MagicMock()
+        if isinstance(sql_row, Exception):
+            result.fetchone.side_effect = sql_row
+        else:
+            result.fetchone.return_value = sql_row
+        return result
+
+    mock_conn.execute.side_effect = _execute
+    mock_engine = MagicMock()
+    mock_engine.connect.return_value.__enter__.return_value = mock_conn
+    engine_patch.return_value = mock_engine
+
+    return stack, mock_es_instance
+
+
+def _run_embedding(label, entity_type, definition, sql_row,
+                   query_vec=None, cache_entries=None):
+    """Drive _check_embedding_duplicate end to end with mocked deps.
+
+    Returns (result, captured) where result is the function's return and
+    captured has 'params' and 'sql' from the simulated SQL call.
+    """
+    if query_vec is None:
+        query_vec = [0.1] * 384  # arbitrary; matcher does not see the vector
+    captured: Dict[str, Any] = {}
+    service = _make_service(cache_entries)
+    with _patch_pgvector(query_vec, sql_row, captured)[0]:
+        result = service._check_embedding_duplicate(label, definition, entity_type)
+    return result, captured
 
 
 # ---------------------------------------------------------------------------
@@ -93,252 +128,269 @@ OBL_URI = "http://proethica.org/ontology/intermediate#ConfidentialityObligation"
 ROLE_URI = "http://proethica.org/ontology/intermediate#FaithfulAgentRole"
 CAP_URI = "http://proethica.org/ontology/intermediate#CompetenceCapability"
 
-OBL_VEC = _make_unit_vec(seed=1)
-ROLE_VEC = _make_unit_vec(seed=2)
-CAP_VEC = _make_unit_vec(seed=3)
-
-INDEX_URIS = [OBL_URI, ROLE_URI, CAP_URI]
-INDEX_TYPES = ["obligation", "role", "capability"]
-INDEX_VECTORS = [OBL_VEC, ROLE_VEC, CAP_VEC]
-
 LEXICAL_CACHE = {
     OBL_URI: {
         'label': 'Confidentiality Obligation',
-        'type': 'obligation',
+        'type': 'class',
         'definition': 'Duty to protect client information',
     },
     ROLE_URI: {
         'label': 'Faithful Agent Role',
-        'type': 'role',
+        'type': 'class',
         'definition': 'Engineer acting as faithful agent for client',
     },
     CAP_URI: {
         'label': 'Competence Capability',
-        'type': 'capability',
+        'type': 'class',
         'definition': 'Professional competence and technical expertise',
     },
 }
 
 
 # ---------------------------------------------------------------------------
-# _check_embedding_duplicate tests
+# _check_embedding_duplicate
 # ---------------------------------------------------------------------------
 
 class TestCheckEmbeddingDuplicate:
-    """Direct unit tests for the embedding similarity path."""
 
-    def _run(self, query_vec, entity_type, *, service=None):
-        if service is None:
-            service = _make_service(INDEX_URIS, INDEX_TYPES, INDEX_VECTORS)
-        mock_emb = MagicMock()
-        mock_emb._get_local_embedding.return_value = query_vec
-        with patch(
-            "app.services.embedding_service.EmbeddingService"
-        ) as MockCls:
-            MockCls.get_instance.return_value = mock_emb
-            return service._check_embedding_duplicate(
-                "Candidate Label", "some definition", entity_type
-            )
-
-    def test_high_cosine_returns_uri_and_high_confidence(self):
-        """cosine >= 0.85 returns (uri, score >= 0.85) -> auto-link band."""
-        query = _vec_with_cosine(OBL_VEC, 0.92)
-        result = self._run(query, "obligation")
+    def test_high_cosine_returns_uri_and_score(self):
+        row = _make_row(OBL_URI, "Confidentiality Obligation", 0.92)
+        result, _ = _run_embedding("Some Duty", "obligation", "", row)
         assert result is not None
         uri, score = result
         assert uri == OBL_URI
-        assert score >= 0.85, f"Expected score >= 0.85, got {score:.4f}"
+        assert score == pytest.approx(0.92)
 
-    def test_medium_cosine_returns_uri_and_medium_confidence(self):
-        """0.70 <= cosine < 0.85 returns (uri, score) in that range -> review-flag."""
-        query = _vec_with_cosine(OBL_VEC, 0.77)
-        result = self._run(query, "obligation")
+    def test_medium_cosine_returns_uri_and_score(self):
+        row = _make_row(OBL_URI, "Confidentiality Obligation", 0.77)
+        result, _ = _run_embedding("Some Duty", "obligation", "", row)
         assert result is not None
         uri, score = result
         assert uri == OBL_URI
-        assert 0.70 <= score < 0.85, f"Expected [0.70, 0.85), got {score:.4f}"
+        assert 0.70 <= score < 0.85
 
     def test_low_cosine_returns_none(self):
-        """cosine < 0.70 returns None -> treat as novel class."""
-        query = _vec_with_cosine(OBL_VEC, 0.60)
-        result = self._run(query, "obligation")
+        """Top match below EMBEDDING_MATCH_MIN is rejected."""
+        row = _make_row(OBL_URI, "Confidentiality Obligation", 0.60)
+        result, _ = _run_embedding("Some Duty", "obligation", "", row)
         assert result is None
 
-    def test_type_filter_blocks_cross_type_match(self):
-        """Obligation candidate must not match a capability class."""
-        # Very close to CAP_VEC but entity_type='obligation'
-        query = _vec_with_cosine(CAP_VEC, 0.95)
-        result = self._run(query, "obligation")
-        # CAP_URI must not be returned (type mismatch)
-        assert result is None or (result[0] != CAP_URI)
-
-    def test_plural_type_passes_filter(self):
-        """'obligations' (plural) should match type 'obligation' in index."""
-        query = _vec_with_cosine(OBL_VEC, 0.90)
-        result = self._run(query, "obligations")
-        assert result is not None
-        uri, score = result
-        assert uri == OBL_URI
-
-    def test_no_type_filter_matches_best_overall(self):
-        """Empty entity_type skips filtering; best cosine across all classes wins."""
-        query = _vec_with_cosine(ROLE_VEC, 0.88)
-        result = self._run(query, "")
-        assert result is not None
-        uri, score = result
-        assert uri == ROLE_URI
-
-    def test_empty_index_returns_none(self):
-        """Empty embedding index returns None without raising."""
-        service = _make_service([], [], [])
-        mock_emb = MagicMock()
-        mock_emb._get_local_embedding.return_value = OBL_VEC
-        with patch("app.services.embedding_service.EmbeddingService") as MockCls:
-            MockCls.get_instance.return_value = mock_emb
-            result = service._check_embedding_duplicate("Any", "", "obligation")
+    def test_no_match_returns_none(self):
+        """Empty SQL result (e.g., empty table or all filtered out)."""
+        result, _ = _run_embedding("Some Duty", "obligation", "", None)
         assert result is None
 
-    def test_returns_best_among_same_type(self):
-        """When multiple same-type classes exist, returns the highest-cosine one."""
-        obl2_vec = _make_unit_vec(seed=10)
-        obl2_uri = "http://proethica.org/ontology/intermediate#NonDisclosureObligation"
-        uris = [OBL_URI, obl2_uri]
-        types = ["obligation", "obligation"]
-        vectors = [OBL_VEC, obl2_vec]
-        service = _make_service(uris, types, vectors)
+    def test_embedding_service_raises_returns_none(self):
+        from contextlib import ExitStack
+        captured: Dict[str, Any] = {}
 
-        # Query is very close to obl2_vec
-        query = _vec_with_cosine(obl2_vec, 0.95)
-        mock_emb = MagicMock()
-        mock_emb._get_local_embedding.return_value = query
-        with patch("app.services.embedding_service.EmbeddingService") as MockCls:
-            MockCls.get_instance.return_value = mock_emb
-            result = service._check_embedding_duplicate(
-                "Non-Disclosure Duty", "", "obligation"
+        service = _make_service()
+        with ExitStack() as stack:
+            es_patch = stack.enter_context(
+                patch("app.services.embedding_service.EmbeddingService")
+            )
+            mock_es = MagicMock()
+            mock_es._get_local_embedding.side_effect = RuntimeError("boom")
+            es_patch.get_instance.return_value = mock_es
+
+            result = service._check_embedding_duplicate("X", "", "obligation")
+        assert result is None
+
+    def test_type_marker_added_to_params_for_obligation(self):
+        row = _make_row(OBL_URI, "Confidentiality Obligation", 0.90)
+        _, captured = _run_embedding("X", "obligation", "", row)
+        # Singular obligation -> 'Obligation' marker
+        marker_values = [v for k, v in captured["params"].items() if k.startswith("m")]
+        assert any("Obligation" in v for v in marker_values), captured["params"]
+
+    def test_plural_type_marker_singularizes(self):
+        row = _make_row(OBL_URI, "Confidentiality Obligation", 0.90)
+        _, captured = _run_embedding("X", "obligations", "", row)
+        marker_values = [v for k, v in captured["params"].items() if k.startswith("m")]
+        # Both plural and singular forms expected
+        assert any("Obligation" in v for v in marker_values), captured["params"]
+
+    def test_capability_plural_singularizes_to_capability(self):
+        """'capabilities' is the irregular plural that the -ies->y rule covers."""
+        row = _make_row(CAP_URI, "Competence Capability", 0.90)
+        _, captured = _run_embedding("X", "capabilities", "", row)
+        marker_values = [v for k, v in captured["params"].items() if k.startswith("m")]
+        assert any("Capability" in v for v in marker_values), captured["params"]
+
+    def test_empty_entity_type_omits_marker_filter(self):
+        """No semantic type -> no LIKE clauses in params (only :vec)."""
+        row = _make_row(OBL_URI, "Confidentiality Obligation", 0.90)
+        _, captured = _run_embedding("X", "", "", row)
+        marker_keys = [k for k in captured["params"].keys() if k.startswith("m")]
+        assert marker_keys == [], captured["params"]
+        assert "vec" in captured["params"]
+
+    def test_definition_concatenated_into_embedding_text(self):
+        """The candidate text passed to EmbeddingService is 'label: definition'."""
+        row = _make_row(OBL_URI, "Confidentiality Obligation", 0.90)
+        captured: Dict[str, Any] = {}
+        service = _make_service()
+
+        from contextlib import ExitStack
+        with ExitStack() as stack:
+            es_patch = stack.enter_context(
+                patch("app.services.embedding_service.EmbeddingService")
+            )
+            engine_patch = stack.enter_context(
+                patch("app.services.auto_commit_service.create_engine")
+            )
+            mock_es = MagicMock()
+            mock_es._get_local_embedding.return_value = [0.1] * 384
+            es_patch.get_instance.return_value = mock_es
+
+            mock_conn = MagicMock()
+            mock_conn.execute.return_value.fetchone.return_value = row
+            mock_engine = MagicMock()
+            mock_engine.connect.return_value.__enter__.return_value = mock_conn
+            engine_patch.return_value = mock_engine
+
+            service._check_embedding_duplicate(
+                "Disclosure Duty",
+                "Engineer must report safety risks",
+                "obligation",
             )
 
-        assert result is not None
-        uri, score = result
-        assert uri == obl2_uri
-        assert score >= 0.85
-
-    def test_embedding_service_exception_returns_none(self):
-        """If EmbeddingService raises, _check_embedding_duplicate returns None."""
-        service = _make_service(INDEX_URIS, INDEX_TYPES, INDEX_VECTORS)
-        mock_emb = MagicMock()
-        mock_emb._get_local_embedding.side_effect = RuntimeError("model not loaded")
-        with patch("app.services.embedding_service.EmbeddingService") as MockCls:
-            MockCls.get_instance.return_value = mock_emb
-            result = service._check_embedding_duplicate("Any Label", "", "obligation")
-        assert result is None
+        called_with = mock_es._get_local_embedding.call_args[0][0]
+        assert called_with == "Disclosure Duty: Engineer must report safety risks"
 
 
 # ---------------------------------------------------------------------------
-# _check_duplicate integration tests (lexical + embedding pipeline)
+# _check_duplicate end-to-end (lexical + embedding fallthrough)
 # ---------------------------------------------------------------------------
 
 class TestCheckDuplicate:
-    """Integration tests for _check_duplicate: lexical paths and embedding fallthrough."""
-
-    def _make_full_service(self):
-        return _make_service(
-            INDEX_URIS, INDEX_TYPES, INDEX_VECTORS,
-            cache_entries=LEXICAL_CACHE,
-        )
 
     def test_exact_label_returns_confidence_one(self):
-        """Exact label match (case-insensitive) returns (uri, 1.0)."""
-        service = self._make_full_service()
+        service = _make_service(LEXICAL_CACHE)
         result = service._check_duplicate("Confidentiality Obligation", "obligation")
-        assert result is not None
-        uri, conf = result
-        assert uri == OBL_URI
-        assert conf == 1.0
+        assert result == (OBL_URI, 1.0)
 
     def test_exact_match_case_insensitive(self):
-        service = self._make_full_service()
+        service = _make_service(LEXICAL_CACHE)
         result = service._check_duplicate("FAITHFUL AGENT ROLE", "role")
-        assert result is not None
-        uri, conf = result
-        assert uri == ROLE_URI
-        assert conf == 1.0
+        assert result == (ROLE_URI, 1.0)
 
     def test_substring_match_returns_0_87(self):
-        """Substring match with matching type returns (uri, 0.87)."""
-        service = self._make_full_service()
-        # 'Faithful' is contained in 'Faithful Agent Role'
+        service = _make_service(LEXICAL_CACHE)
         result = service._check_duplicate("Faithful", "role")
         assert result is not None
         uri, conf = result
         assert uri == ROLE_URI
         assert conf == pytest.approx(0.87)
 
-    def test_substring_wrong_type_does_not_match_lexically(self):
-        """Substring match with mismatched type is not returned from lexical path."""
-        service = self._make_full_service()
-        # 'Competence' is a substring of 'Competence Capability' (type=capability)
-        # Querying with obligation type -> lexical path blocked
-        # Use a query vector with cosine below EMBEDDING_MATCH_MIN so it returns None
-        query = _vec_with_cosine(CAP_VEC, 0.50)
-        mock_emb = MagicMock()
-        mock_emb._get_local_embedding.return_value = query
-        with patch("app.services.embedding_service.EmbeddingService") as MockCls:
-            MockCls.get_instance.return_value = mock_emb
+    def test_substring_wrong_type_falls_through_to_embedding(self):
+        """Substring 'Competence' matches a Capability class label, but candidate
+        type 'obligation' should make the URI-marker filter reject it. The flow
+        then reaches the embedding path, which we mock to return None."""
+        service = _make_service(LEXICAL_CACHE)
+        from contextlib import ExitStack
+        with ExitStack() as stack:
+            es_patch = stack.enter_context(
+                patch("app.services.embedding_service.EmbeddingService")
+            )
+            engine_patch = stack.enter_context(
+                patch("app.services.auto_commit_service.create_engine")
+            )
+            es_patch.get_instance.return_value._get_local_embedding.return_value = [0.1] * 384
+            mock_conn = MagicMock()
+            mock_conn.execute.return_value.fetchone.return_value = None
+            engine_patch.return_value.connect.return_value.__enter__.return_value = mock_conn
+
             result = service._check_duplicate("Competence", "obligation")
         assert result is None
 
-    def test_unknown_label_falls_through_to_embedding_high(self):
-        """Unknown label with no lexical match uses embedding path at high cosine."""
-        service = self._make_full_service()
-        query = _vec_with_cosine(OBL_VEC, 0.91)
-        mock_emb = MagicMock()
-        mock_emb._get_local_embedding.return_value = query
-        with patch("app.services.embedding_service.EmbeddingService") as MockCls:
-            MockCls.get_instance.return_value = mock_emb
+    def test_unknown_label_falls_through_to_embedding_match(self):
+        service = _make_service(LEXICAL_CACHE)
+        from contextlib import ExitStack
+        with ExitStack() as stack:
+            es_patch = stack.enter_context(
+                patch("app.services.embedding_service.EmbeddingService")
+            )
+            engine_patch = stack.enter_context(
+                patch("app.services.auto_commit_service.create_engine")
+            )
+            es_patch.get_instance.return_value._get_local_embedding.return_value = [0.1] * 384
+            mock_conn = MagicMock()
+            mock_conn.execute.return_value.fetchone.return_value = _make_row(
+                OBL_URI, "Confidentiality Obligation", 0.91,
+            )
+            engine_patch.return_value.connect.return_value.__enter__.return_value = mock_conn
+
             result = service._check_duplicate(
                 "Client Data Protection Duty", "obligation"
             )
         assert result is not None
         uri, conf = result
         assert uri == OBL_URI
-        assert conf >= 0.85
+        assert conf == pytest.approx(0.91)
 
-    def test_unknown_label_falls_through_to_embedding_novel(self):
-        """Unknown label below embedding threshold returns None (novel class)."""
-        service = self._make_full_service()
-        query = _vec_with_cosine(OBL_VEC, 0.50)
-        mock_emb = MagicMock()
-        mock_emb._get_local_embedding.return_value = query
-        with patch("app.services.embedding_service.EmbeddingService") as MockCls:
-            MockCls.get_instance.return_value = mock_emb
+    def test_unknown_label_below_threshold_returns_none(self):
+        service = _make_service(LEXICAL_CACHE)
+        from contextlib import ExitStack
+        with ExitStack() as stack:
+            es_patch = stack.enter_context(
+                patch("app.services.embedding_service.EmbeddingService")
+            )
+            engine_patch = stack.enter_context(
+                patch("app.services.auto_commit_service.create_engine")
+            )
+            es_patch.get_instance.return_value._get_local_embedding.return_value = [0.1] * 384
+            mock_conn = MagicMock()
+            mock_conn.execute.return_value.fetchone.return_value = _make_row(
+                OBL_URI, "Confidentiality Obligation", 0.50,
+            )
+            engine_patch.return_value.connect.return_value.__enter__.return_value = mock_conn
+
             result = service._check_duplicate(
                 "CompletelyUnrelatedConcept999", "obligation"
             )
         assert result is None
 
-    def test_empty_cache_returns_none_immediately(self):
-        """Empty OntServe cache returns None without reaching embedding path."""
-        service = _make_service([], [], [], cache_entries={})
-        result = service._check_duplicate("Any Label", "role")
+    def test_empty_cache_no_sql_row_returns_none(self):
+        service = _make_service({})
+        from contextlib import ExitStack
+        with ExitStack() as stack:
+            es_patch = stack.enter_context(
+                patch("app.services.embedding_service.EmbeddingService")
+            )
+            engine_patch = stack.enter_context(
+                patch("app.services.auto_commit_service.create_engine")
+            )
+            es_patch.get_instance.return_value._get_local_embedding.return_value = [0.1] * 384
+            mock_conn = MagicMock()
+            mock_conn.execute.return_value.fetchone.return_value = None
+            engine_patch.return_value.connect.return_value.__enter__.return_value = mock_conn
+
+            result = service._check_duplicate("Any Label", "role")
         assert result is None
 
-    def test_definition_passed_to_embedding(self):
-        """Definition argument is forwarded to _check_embedding_duplicate."""
-        service = self._make_full_service()
-        query = _vec_with_cosine(OBL_VEC, 0.88)
-        mock_emb = MagicMock()
-        mock_emb._get_local_embedding.return_value = query
-        with patch("app.services.embedding_service.EmbeddingService") as MockCls:
-            MockCls.get_instance.return_value = mock_emb
-            result = service._check_duplicate(
-                "Duty of Confidentiality",
-                "obligation",
+    def test_definition_passed_through_to_embedding(self):
+        service = _make_service(LEXICAL_CACHE)
+        from contextlib import ExitStack
+        with ExitStack() as stack:
+            es_patch = stack.enter_context(
+                patch("app.services.embedding_service.EmbeddingService")
+            )
+            engine_patch = stack.enter_context(
+                patch("app.services.auto_commit_service.create_engine")
+            )
+            mock_es = MagicMock()
+            mock_es._get_local_embedding.return_value = [0.1] * 384
+            es_patch.get_instance.return_value = mock_es
+            mock_conn = MagicMock()
+            mock_conn.execute.return_value.fetchone.return_value = _make_row(
+                OBL_URI, "Confidentiality Obligation", 0.88,
+            )
+            engine_patch.return_value.connect.return_value.__enter__.return_value = mock_conn
+
+            service._check_duplicate(
+                "Duty of Confidentiality", "obligation",
                 "Engineer must keep client secrets",
             )
-        # Should succeed via embedding
-        assert result is not None
-        # EmbeddingService was called (embedding path was reached)
-        mock_emb._get_local_embedding.assert_called()
-        # The call text should include the definition
-        call_args = mock_emb._get_local_embedding.call_args[0][0]
-        assert "Engineer must keep client secrets" in call_args
+        passed = mock_es._get_local_embedding.call_args[0][0]
+        assert "Engineer must keep client secrets" in passed


### PR DESCRIPTION
Issue 1 of the post-ICCBR canonicalization plan
(`proethica/.claude/plans/post-iccbr-canonicalization.md`).

## What this changes

PR #4 introduced an embedding-based duplicate matcher that built a
per-process in-memory numpy index by re-embedding all ~5,400 proethica
classes on cache load. The OntServe DB schema already had populated
embeddings (`ontology_entities.embedding`, `vector(384)`) and an IVFFlat
cosine index, so the in-memory pipeline was redundant work.

This PR drops `_build_embedding_index` entirely and rewrites
`_check_embedding_duplicate` to run a single pgvector cosine query.

### Cold-start cost

| Implementation | Cold start (per-process, first match) |
|---|---|
| In-memory (PR #4) | ~5s GPU, much longer CPU |
| pgvector query (this PR) | <500ms |

### IVFFlat probes note

The query runs `SET LOCAL ivfflat.probes = 100` before the SELECT.
Default `probes=1` is approximate and missed the true nearest neighbour
in integration tests (returned cosine 0.65 instead of the actual 0.71).
With 5,558 classes across 100 lists, `probes=100` is effectively exact
via the index structure.

## Tests

`tests/test_embedding_matcher.py` rewritten to mock `create_engine` and
`EmbeddingService` directly. **18/18 pass**. Coverage:

- High / medium / low cosine bands
- Empty SQL result, exception handling
- Type-marker LIKE clauses in SQL params (verifies plural / singular
  singularization, irregular `-ies` plural, missing-type fallthrough)
- Definition concatenation into embedding text
- Exact and substring lexical paths still work
- Embedding fallthrough when lexical paths miss

## Integration verified

Against populated local OntServe (5,558 class embeddings). Same five
canonical candidates produce identical results to the prior in-memory
implementation:

| Candidate | Result |
|---|---|
| Faithful Agent Obligation | exact 1.000 |
| Engineer's Duty to Faithfully Represent Client Interests | 0.711 |
| Public Welfare Safety Concern Obligation | 0.769 |
| Quantum Cryptography Standards Compliance Capability | novel |
| Confidentiality Obligation | exact 1.000 |

## Side cleanup

Removed two redundant local `from sqlalchemy import create_engine`
imports that shadowed the module-level import and complicated mocking.

## Follow-ups not in this PR

Tracked in `proethica/.claude/plans/post-iccbr-canonicalization.md`:
- Issue 2: surface review-band matches in entity-review UI
- Issue 3: cosine threshold calibration against gold pairs
- Issue 4: subclass-chain emission writeup
- Issue 5: replace heuristic `_semantic_type_markers` with explicit map