### PR TITLE
Restore Validation Studies docs after study UI stabilization

### DIFF
--- a/docs/admin-guide/index.md
+++ b/docs/admin-guide/index.md
@@ -29,6 +29,7 @@ A progress indicator shows completion status across the eight-step workflow from
 | [Pipeline Management](pipeline-management.md) | `/pipeline/dashboard` | Batch processing and queue management |
 | [User Management](user-management.md) | `/admin/users` | Manage user accounts |
 | [Service Health](health-dashboard.md) | `/health/status` | Service-monitoring dashboard |
+| [Validation Study](validation-studies.md) | `/validation/admin/dashboard` | Study enrollment, coverage, and results export |
 
 ## System Configuration
 
@@ -51,4 +52,4 @@ The Tools dropdown organizes into three groups:
 
 - **Academic References** - Available to all users
 - **Linked Data** - OntServe Web, Browse ProEthica Ontologies
-- **Admin Tools** (admin login required) -- Batch Processing, Batch Queue, Prompt Editor
+- **Admin Tools** (admin login required) -- Batch Processing, Batch Queue, Prompt Editor, Validation Study

--- a/docs/admin-guide/validation-participant-flow.md
+++ b/docs/admin-guide/validation-participant-flow.md
@@ -1,0 +1,86 @@
+# Validation Study Participant Flow
+
+The validation study is accessible at `/validation/`. Participation does not require a ProEthica account; authentication is by possession of a randomly generated participant code only. The study was conducted under IRB Protocol 2603011709.
+
+## Recruitment Channels
+
+Two recruitment channels were used:
+
+| Channel | Identifier | Notes |
+|---------|-----------|-------|
+| Prolific (engineering-trained) | `prolific_engineering_trained` | Primary channel; participants pre-screened for engineering background via Prolific prescreening |
+| Drexel students | `drexel_student` | Opportunistic channel (senior-design cohort); dormant at time of main data collection |
+
+Prolific participants arrive via a URL carrying `prolific_pid`, `study_id`, and `session_id` query parameters. The system stashes these in the browser session for later persistence and renders the HRP-506b information sheet for the adult-population channel. Drexel participants receive the HRP-506 information sheet.
+
+## Participant Flow
+
+### Step 1: Consent
+
+The landing page (`/validation/`) displays the study information sheet (HRP-506 or HRP-506b, depending on channel). The participant must check a consent acknowledgement before proceeding. On submission to `/validation/enroll`, the system:
+
+- Generates a random 8-character participant code from an ambiguity-stripped alphabet (no `0`/`O`, `1`/`I`/`L`).
+- Assigns 3–4 cases from the 23-case study pool via `case_assignment_service.assign_cases`.
+- Creates a `ValidationSession` record with `consent_acknowledged_at` and `info_sheet_version` stamped.
+- Stores the participant code in the browser session cookie.
+
+For Prolific participants, a SHA-256 hash of the Prolific PID is stored on the session record for duplicate-enrollment detection. The plain PID is never persisted.
+
+### Step 2: Orientation
+
+After consent, participants land at `/validation/orientation`. This screen describes the per-case workflow, explains the five synthesis views, and outlines the post-cases steps. On form submission, `orientation_completed_at` is stamped and the participant is redirected to the study dashboard. Returning participants (resuming by code) skip orientation if `orientation_completed_at` is already set.
+
+### Step 3: Study Dashboard
+
+The study dashboard (back at `/validation/`, with the code present) shows the assigned cases, completion status for each, and overall progress. From here, the participant navigates to each assigned case.
+
+### Step 4: Case Evaluation
+
+Each case evaluation (`/validation/case/<id>`) proceeds through four steps controlled by the `?step=` URL parameter:
+
+| Step (URL) | Content | Gate |
+|-----------|---------|------|
+| `facts` | Case facts; Discussion and Conclusions withheld | None |
+| `views` | Five synthesis views (Provisions, Q&C, Decisions, Timeline, Narrative) with inline 3-item Likert ratings per view (15 items total) | None |
+| `comprehension` | Three Overall utility items, including the reverse-coded attention-check item | All 15 per-view items must be rated |
+| `reveal` | Board Discussion and Conclusions revealed; alignment self-rating | All 18 items must be rated |
+
+Each of the five views presents three 7-point Likert items (1 = Strongly Disagree, 7 = Strongly Agree). The Overall section adds three additional items; `overall_surfaced_considerations` is reverse-coded when computing view means. The server enforces step gates: navigating to `comprehension` without completing per-view ratings, or to `reveal` without completing the Overall items, redirects back to the preceding step.
+
+Evaluation data is stored in `ViewUtilityEvaluation`. The record is created on first submit and updated on subsequent submits until `completed_at` is stamped.
+
+### Step 5: Retrospective
+
+After all assigned cases are completed, the participant proceeds to `/validation/retrospective`. This page collects:
+
+- A drag-and-drop ranking of the five views from most valuable (rank 1) to least valuable (rank 5). The view list is shuffled on render to prevent order bias. Rankings must be a valid 1–5 permutation (no ties) before submission is accepted.
+- An open-text field for missed considerations or general feedback.
+
+Submission is one-shot. Once `completed_at` is stamped on the `ValidationSession`, further attempts to access the retrospective form are redirected to the completion screen.
+
+Data is stored in `RetrospectiveReflection`.
+
+### Step 6: Completion
+
+The completion screen at `/validation/complete` presents the outcome by channel:
+
+- **Prolific participants**: a "Return to Prolific" button that redirects to Prolific's submission URL with the study completion code as the `cc` parameter. A manual-paste fallback is shown in case the redirect fails.
+- **Drexel-channel participants**: a per-session confirmation reference code.
+
+The completion code (`ValidationSession.completion_code`) is distinct from the participant code. It is generated at the moment of completion and is what participants submit to the crowdsourcing platform; it is not the participant's identifying code.
+
+## Session Resume
+
+A participant who closes the browser mid-study can return by navigating to `/validation/` and entering their participant code. The code can also be supplied as a query parameter: `/validation/?code=XXXXXXXX`. Orientation is skipped on resume if already completed. The session resumes at the study dashboard, from which the participant continues with incomplete cases.
+
+## Data Model
+
+| Table | Rows | Contents |
+|-------|------|----------|
+| `validation_sessions` | One per participant | Consent timestamp, assigned cases, completion status, channel, Prolific PID hash |
+| `view_utility_evaluations` | One per participant per case | 18 Likert items, 4 comprehension responses, alignment rating |
+| `retrospective_reflections` | One per participant | Five-view ranking, open-text feedback |
+
+## Related Documentation
+
+- [Validation Study Admin Dashboard](validation-studies.md) - Monitoring, export, and results visualizations

--- a/docs/admin-guide/validation-studies.md
+++ b/docs/admin-guide/validation-studies.md
@@ -1,0 +1,76 @@
+# Validation Study Admin Dashboard
+
+The validation study admin dashboard at `/validation/admin/dashboard` provides operational monitoring and data export for the view-utility study conducted under IRB Protocol 2603011709. Admin authentication is required in production.
+
+The study collected perceived-utility ratings for five synthesis views (Provisions, Q&C, Decisions, Timeline, Narrative) from engineering-trained participants. Data collection was conducted via Prolific. The dashboard filters to verified recruitment sources by default; preview and Drexel-student dormant-channel sessions are excluded from dashboard aggregations but remain accessible via the export endpoint.
+
+## Dashboard Sections
+
+### Enrollment Statistics
+
+Four summary cards at the top of the page display:
+
+| Metric | Description |
+|--------|-------------|
+| Enrolled | Total participants from real recruitment channels |
+| Completed | Participants who submitted the retrospective reflection |
+| In Progress | Enrolled but not yet finished |
+| Total Evaluations | Completed per-case rating forms across all participants |
+
+### Case Coverage
+
+A table lists all 23 cases in the study pool with the count of distinct raters per case. Cases meeting or exceeding the Krippendorff floor of n=5 raters are marked as threshold-met; cases below the floor are listed in a separate under-threshold section. This view is the primary tool for monitoring whether each case has received sufficient coverage for inter-rater reliability analysis.
+
+### Data Quality Flags
+
+Two quality indicators are shown:
+
+| Flag | Derivation |
+|------|------------|
+| Attention check pass rate | Percentage of evaluations where `overall_surfaced_considerations` (a reverse-coded item) was answered as 1 |
+| Low-effort flags | Count of evaluations where `low_effort_flag` is set |
+
+### Recent Sessions
+
+A table of the ten most recent enrolled sessions from real recruitment channels, ordered by enrollment time descending. Columns include participant code (truncated), source channel, progress, and completion status.
+
+### Results Visualizations
+
+The bottom section aggregates collected data into three views:
+
+**Per-view mean utility scores.** For each of the five views and the Overall row, the dashboard reports the mean, standard deviation, and rater count across all completed evaluations. Scores are on the 1–7 Likert scale; `overall_surfaced_considerations` is reverse-coded before the mean is computed.
+
+**Retrospective view rankings.** A stacked count showing, for each view, how many participants assigned it each rank from 1 (most valuable) to 5 (least). Data source: `RetrospectiveReflection.rank_*_view` columns.
+
+**Per-case means.** Mean overall utility score per case, sorted descending, restricted to cases with at least one completed evaluation from a real channel.
+
+## Admin Endpoints
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/validation/admin/dashboard` | GET | Dashboard described above |
+| `/validation/admin/export` | GET | Download per-item or per-view-mean data |
+| `/validation/admin/summary` | GET | JSON comparison summary |
+| `/validation/admin/evaluator-progress` | GET | JSON per-evaluator progress |
+
+### Export Parameters
+
+`/validation/admin/export` accepts the following query parameters:
+
+| Parameter | Default | Values |
+|-----------|---------|--------|
+| `format` | `csv` | `csv`, `json` |
+| `domain` | `engineering` | `engineering`, `all` |
+| `level` | `means` | `means` (per-view averages), `items` (per-item rows for Krippendorff) |
+
+`level=items` returns one row per evaluator per case with all 18 individual Likert responses. `level=means` returns per-view aggregated means and is the default for general inspection.
+
+## Access Control
+
+All admin endpoints are protected by `@admin_required_production`. In development mode, the restriction is relaxed. See [Settings](settings.md#security-settings) for authentication configuration.
+
+## Related Documentation
+
+- [Validation Participant Flow](validation-participant-flow.md) - Participant experience and data model
+- [Service Health](health-dashboard.md) - Operational monitoring
+- [Settings](settings.md) - Environment configuration

--- a/docs/getting-started/first-login.md
+++ b/docs/getting-started/first-login.md
@@ -26,7 +26,7 @@ The top navigation provides access to main features:
 | **Case Relations** | Dropdown | Similar Cases, Similarity Network, Lineage Graph |
 | **Guidelines** | Link | Browse ethical guidelines and codes of ethics |
 | **Docs** | Link | This documentation |
-| **Tools** | Dropdown | Academic References; Linked Data (OntServe Web, Browse ProEthica Ontologies); Admin Tools (Batch Processing, Batch Queue, Prompt Editor) |
+| **Tools** | Dropdown | Academic References; Linked Data (OntServe Web, Browse ProEthica Ontologies); Admin Tools (Batch Processing, Batch Queue, Prompt Editor, Validation Study) |
 | **[User]** | Dropdown | User menu with Logout |
 
 ![Case Relations Dropdown](../assets/images/screenshots/navbar-case-relations-dropdown.png)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,6 +94,8 @@ nav:
       - Ontology Integration: admin-guide/ontology-integration.md
       - Production Server: admin-guide/production-server.md
       - Settings: admin-guide/settings.md
+      - Validation Study Dashboard: admin-guide/validation-studies.md
+      - Validation Participant Flow: admin-guide/validation-participant-flow.md
   - Publications: papers/index.md
   - "Back to ProEthica": "/"
 


### PR DESCRIPTION
## Summary

- Validation Studies references were removed from the public MkDocs site on **2026-04-30** during a docs audit because the study was in flux (dual-channel pivot on 2026-04-28; Prolific batch not yet launched).
- The Prolific batch launched **2026-05-18**. Data collection closed **2026-05-26** (commit `88384d1` notes "study closed" explicitly). No study UI commits have landed in the 13 days since, and the `ValidationSession` schema has been stable at v6 since 2026-04-16.
- This PR restores the docs as scheduled by the 2026-04-30 deferral, targeting 2026-06-08.

## Changes

**New pages:**
- `docs/admin-guide/validation-studies.md` — admin dashboard at `/validation/admin/dashboard`: enrollment statistics, case coverage against the 23-case pool (n≥5 Krippendorff floor), data-quality flags (attention check, low-effort), recent sessions, results visualizations, and export endpoint parameters.
- `docs/admin-guide/validation-participant-flow.md` — participant experience at `/validation/`: consent and enrollment, orientation, study dashboard, four-step case evaluation (facts → views + inline Likert ratings → reflection → wrap-up/reveal), retrospective ranking, completion screen, session resume, and data model overview.

**Updated files:**
- `mkdocs.yml` — both pages added under the Administration nav section.
- `docs/admin-guide/index.md` — Validation Study row in the Administrative Functions table; "Validation Study" appended to the Admin Tools list.
- `docs/getting-started/first-login.md` — Tools dropdown description updated to include Validation Study.

## Reference

Deferral context: `docs-internal/conferences_submissions/CLAUDE.md` (section: "Public docs follow-up (added 2026-04-30)").

https://claude.ai/code/session_017is2dKRsr5JoKK8a2BS4me

---
_Generated by [Claude Code](https://claude.ai/code/session_017is2dKRsr5JoKK8a2BS4me)_